### PR TITLE
7 modify defining relation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ myst_enable_extensions = ["dollarmath"]
 
 pygments_style = "sphinx"
 
-autodoc_mock_imports = ["numpy", "oapackage"]
+autodoc_mock_imports = ["numpy", "oapackage", "pandas"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/fatld/design.py
+++ b/fatld/design.py
@@ -6,7 +6,8 @@ import numpy as np
 import oapackage as oa  # type: ignore
 import pandas as pd  # type: ignore
 
-from .main import basic_factor_matrix, custom_design, power2_decomposition, twlp
+from .main import basic_factor_matrix, custom_design, twlp
+from .relation import Relation, num2gen
 
 
 class Design:
@@ -108,6 +109,7 @@ class Design:
         self.p = len(cols)
         # List of added factors
         self.af = cols
+        self.af.sort()
         # List of all two-level columns in the design
         self.cols = self.bf + self.af
         self.cols.sort()
@@ -430,30 +432,10 @@ class Design:
         List[str]
             Defining relation as a list of words
         """
-        letters = [chr(97 + i) for i in range(self.k)]
-        added_factors = [chr(97 + self.k + i) for i in range(self.p)]
-        relation = []
-        for idx, col in enumerate(self.af):
-            col_powers = power2_decomposition(col, length=self.k)
-            word = "".join([letters[i] for i, x in enumerate(col_powers) if x == 1])
-            relation.append(f"{word}{added_factors[idx]}")
-        if raw:
-            return relation
-        for i in range(self.m):
-            pf_factors = [
-                chr(97 + 2 * i),
-                chr(97 + 2 * i + 1),
-                f"{chr(97 + 2 * i)}{chr(97 + 2 * i + 1)}",
-            ]
-            pf_labels = [f"{chr(65 + i)}{x}" for x in [1, 2, 3]]
-            # We start with p1p2 to avoid replacing p1/p2 first and not the interaction
-            relation = [
-                s.replace(pf_factors[2], pf_labels[2])
-                .replace(pf_factors[1], pf_labels[1])
-                .replace(pf_factors[0], pf_labels[0])
-                for s in relation
-            ]
-        return relation
+        relation = [
+            f"{num2gen(x)}{chr(97 + self.k + i)}" for i, x in enumerate(self.af)
+        ]
+        return Relation(words=relation, m=self.m)
 
     def add_factor(self, number: int):
         """

--- a/fatld/design.py
+++ b/fatld/design.py
@@ -410,7 +410,7 @@ class Design:
                 count += 1
         return count
 
-    def defining_relation(self, raw: bool = False) -> List[str]:
+    def defining_relation(self, raw: bool = False):
         """
         Generate the defining relation of the design.
 
@@ -429,8 +429,8 @@ class Design:
 
         Returns
         -------
-        List[str]
-            Defining relation as a list of words
+        Relation
+            Defining relation as a ``Relation`` object.
         """
         relation = [
             f"{num2gen(x)}{chr(97 + self.k + i)}" for i, x in enumerate(self.af)

--- a/fatld/relation.py
+++ b/fatld/relation.py
@@ -163,6 +163,7 @@ def word_type(word: str) -> int:
 
 
 class Relation:
+    # TODO: document the relation class
     def __init__(self, words: List[str], m: int = 0):
         # `m` can only be 0, 1,2 or 3 since there can't be more four-level factors
         # 0 means there are no four-level factors

--- a/fatld/relation.py
+++ b/fatld/relation.py
@@ -250,5 +250,5 @@ class Relation:
             t = types[i]
             wlp[x][t] += 1
         if self.m == 0:
-            return list(chain(*wlp[3:]))
+            return list(chain(*wlp[3:]))  # type: ignore
         return wlp[3:]

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -5,8 +5,8 @@ Created on: 09/02/2023
 Author: Alexandre Bohyn
 """
 import numpy as np
-import pandas as pd
-import pytest
+import pandas as pd  # type: ignore
+import pytest  # type: ignore
 
 import fatld
 

--- a/tests/test_design.py
+++ b/tests/test_design.py
@@ -19,6 +19,7 @@ class TestDesignErrors:
 class TestDesignMethods:
     # Design 6 from Table 3 of Wu (1993)
     design = fatld.Design(runsize=32, m=1, cols=[29, 26, 22])
+    relation = fatld.relation.Relation(["bcef", "bdeg", "acdeh"], m=1)
 
     def test_twlp(self):
         twlp = self.design.twlp(max_length=5)
@@ -39,6 +40,10 @@ class TestDesignMethods:
     def test_flatten_zero_coding(self):
         flat_array = self.design.flatten(zero_coding=False)
         assert all(np.unique(flat_array) == [-1, 1])
+
+    def test_relation(self):
+        rel = self.design.defining_relation()
+        assert rel.words == self.relation.words
 
 
 class TestCols:


### PR DESCRIPTION
Two issues are fixed:
- defining relation method of the `Design` class now returns a `Relation`object
- docs should build because `pandas` has been added to the mock packages (solves issue #9 )